### PR TITLE
Fix download button generating 10KB dummy files by resolving asset URL correctly

### DIFF
--- a/src/pages/en/works/[slug].astro
+++ b/src/pages/en/works/[slug].astro
@@ -78,11 +78,11 @@ const descriptionHtml = await marked.parse(data.description[lang]);
                 {t('work.download')}
               </button>
               <div id="format-options" class="mt-3 hidden flex flex-col gap-3">
-                <button id="download-glb" class="brutal-btn brutal-btn-black w-full justify-center" data-href={data.model.glb} data-filename={`${work.id}.glb`}>
+                <button id="download-glb" class="brutal-btn brutal-btn-black w-full justify-center" data-href={getAssetUrl(data.model.glb)} data-filename={`${work.id}.glb`}>
                   {t('work.downloadGLB')}
                 </button>
                 {data.model.usdz && (
-                  <button id="download-usdz" class="brutal-btn brutal-btn-black w-full justify-center" data-href={data.model.usdz} data-filename={`${work.id}.usdz`}>
+                  <button id="download-usdz" class="brutal-btn brutal-btn-black w-full justify-center" data-href={getAssetUrl(data.model.usdz)} data-filename={`${work.id}.usdz`}>
                     {t('work.downloadUSDZ')}
                   </button>
                 )}

--- a/src/pages/werke/[slug].astro
+++ b/src/pages/werke/[slug].astro
@@ -78,11 +78,11 @@ const descriptionHtml = await marked.parse(data.description[lang]);
                 {t('work.download')}
               </button>
               <div id="format-options" class="mt-3 hidden flex flex-col gap-3">
-                <button id="download-glb" class="brutal-btn brutal-btn-black w-full justify-center" data-href={data.model.glb} data-filename={`${work.id}.glb`}>
+                <button id="download-glb" class="brutal-btn brutal-btn-black w-full justify-center" data-href={getAssetUrl(data.model.glb)} data-filename={`${work.id}.glb`}>
                   {t('work.downloadGLB')}
                 </button>
                 {data.model.usdz && (
-                  <button id="download-usdz" class="brutal-btn brutal-btn-black w-full justify-center" data-href={data.model.usdz} data-filename={`${work.id}.usdz`}>
+                  <button id="download-usdz" class="brutal-btn brutal-btn-black w-full justify-center" data-href={getAssetUrl(data.model.usdz)} data-filename={`${work.id}.usdz`}>
                     {t('work.downloadUSDZ')}
                   </button>
                 )}


### PR DESCRIPTION
## Problem

After merging the download button feature, clicking download generated ~10KB files instead of the actual model files.

This happened because the download buttons were using raw asset paths:

    data-href={data.model.glb}
    data-href={data.model.usdz}

When deployed under a subpath (e.g. GitHub Pages or non-root base path), these relative URLs resolved incorrectly and returned an HTML fallback or placeholder response instead of the real asset.

## Solution

Updated the download URLs to use `getAssetUrl()`:

    data-href={getAssetUrl(data.model.glb)}
    data-href={getAssetUrl(data.model.usdz)}

This ensures the asset URLs respect the configured base path and match the URLs used by the 3D viewer.

## Result

- Download button now retrieves the correct model files.
- Prevents downloading HTML fallback files (~10KB).
- Aligns download logic with existing asset loading behavior.

## Testing

- Verified download of GLB and USDZ files locally.
- Confirmed correct asset URLs in browser Network tab.
- Downloaded files match expected size/content.

Fixes #9