### PR TITLE
🍱 Add three Göttingen works JSON

### DIFF
--- a/src/content/works/die-heilige-eligia.json
+++ b/src/content/works/die-heilige-eligia.json
@@ -1,0 +1,35 @@
+{
+  "title": {
+    "de": "die-heilige-eligia",
+    "en": "saint-eligia"
+  },
+  "description": {
+    "de": "Die Skulptur 'Die heilige Eligia' ist ein faszinierendes Kunstwerk im öffentlichen Raum von Göttingen, das sich an der Außenfassade des Gebäudes in der Jüdenstraße 33 befindet. Sie wurde von dem Künstler Bernd Löning geschaffen, der auch für andere markante Betonskulpturen in der Stadt bekannt ist. Die Figur blickt von ihrer Konsole herab auf die Passanten und fügt sich harmonisch in das historische Stadtbild ein.\n\nDie Darstellung der Eligia ist eine künstlerische Interpretation einer Schutzpatronin, wobei der Name oft als weibliche Form von Eligius assoziiert wird, dem Patron der Goldschmiede und Metallarbeiter. In Lönings charakteristischem Stil ist die Figur eher grob und ausdrucksstark geformt, was ihr eine zeitlose, fast archaische Präsenz verleiht. Diese bewusste Reduktion auf wesentliche Formen lenkt den Fokus auf die spirituelle und schützende Aura der Figur.\n\nTechnisch gesehen ist die Skulptur ein hervorragendes Beispiel für Lönings Arbeit mit gegossenem Beton. Dieses moderne, industrielle Material wird hier genutzt, um eine sakral anmutende Figur zu erschaffen, was einen spannenden dialektischen Kontrast erzeugt. Die Oberflächenbeschaffenheit des Betons reagiert über die Jahre auf die Witterungseinflüsse, wodurch das Kunstwerk eine natürliche Patina erhält und Teil der lebendigen Stadtgeschichte wird.",
+    "en": "The sculpture 'Saint Eligia' is a fascinating piece of public art in Göttingen, located on the exterior facade of the building at Jüdenstraße 33. It was created by the artist Bernd Löning, who is well-known for other distinctive concrete sculptures throughout the city. The figure gazes down from its console upon passersby, blending harmoniously into the historical cityscape.\n\nThe depiction of Eligia is an artistic interpretation of a patron saint, with the name often associated as the feminine form of Eligius, the patron saint of goldsmiths and metalworkers. In Löning's characteristic style, the figure is shaped with a bold and expressive form, giving it a timeless, almost archaic presence. This deliberate reduction to essential shapes directs the focus toward the spiritual and protective aura of the character.\n\nTechnically, the sculpture is an excellent example of Löning's work with cast concrete. This modern, industrial material is used here to create a figure with a sacred feel, generating a compelling dialectical contrast. The surface texture of the concrete reacts to weathering over the years, allowing the artwork to acquire a natural patina and become a living part of the city's history."
+  },
+  "category": "kunstwerk",
+  "city": "Göttingen",
+  "country": "Germany",
+  "model": {
+    "glb": "/models/die-heilige-eligia.glb",
+    "usdz": "/models/die-heilige-eligia.usdz"
+  },
+  "photos": [
+    "/images/die-heilige-eligia-2.png",
+    "/images/die-heilige-eligia-3.png",
+    "/images/die-heilige-eligia-4.png",
+    "/images/die-heilige-eligia-5.png"
+  ],
+  "poster": "/images/die-heilige-eligia-poster.png",
+  "location": {
+    "lat": 51.53501,
+    "lng": 9.93635,
+    "address": "Jüdenstraße 33, 37073 Göttingen, Germany"
+  },
+  "artist": "Bernd Löning",
+  "year": "2008",
+  "material": {
+    "de": "Beton",
+    "en": "Concrete"
+  }
+}

--- a/src/content/works/jakobus-skulptur-goettingen.json
+++ b/src/content/works/jakobus-skulptur-goettingen.json
@@ -1,0 +1,35 @@
+{
+  "title": {
+    "de": "jakobus-skulptur-goettingen",
+    "en": "jacobus-sculpture-goettingen"
+  },
+  "description": {
+    "de": "Die Jakobus-Skulptur in Göttingen ist ein markantes zeitgenössisches Denkmal, das sich an der Ostseite des Jacobikirchhofs, nahe der Jüdenstraße, befindet. Das Werk wurde von dem Bildhauer Bernd Löning aus Bad Gandersheim geschaffen und im Jahr 2008 aufgestellt. Gestiftet wurde die Skulptur von Gisela Hyllus, der Inhaberin der Galerie Alte Feuerwache, als künstlerischer Beitrag zum öffentlichen Raum der Stadt.\n\nDie Figur stellt den heiligen Jakobus den Älteren dar, den Schutzpatron der Pilger und Namensgeber der angrenzenden St. Jacobi-Kirche. Da Göttingen am historischen Jakobsweg liegt, dient die Skulptur als wichtiger Orientierungspunkt und Symbol für die lange Tradition der Pilgerschaft in dieser Region. Die Darstellung verzichtet auf filigrane Details und setzt stattdessen auf eine kraftvolle, fast archaische Formsprache, die die Beständigkeit des Glaubens und den beschwerlichen Weg der Pilger versinnbildlicht.\n\nTechnisch zeichnet sich das Werk durch die Verwendung von Beton aus, einem Material, mit dem Bernd Löning bevorzugt arbeitet. Der Künstler, der seine Laufbahn als Autodidakt begann, ist für seine Arbeiten im Grenzbereich zwischen angewandter und freier Kunst bekannt. Die robuste Beschaffenheit des Materials verleiht der Skulptur eine moderne Ästhetik, die in spannungsvollem Kontrast zur gotischen Architektur der benachbarten Kirche steht.",
+    "en": "The Jacobus sculpture in Göttingen is a striking contemporary monument located on the eastern side of the Jacobikirchhof, near Jüdenstraße. The piece was created by the sculptor Bernd Löning from Bad Gandersheim and was installed in 2008. It was donated by Gisela Hyllus, owner of the Galerie Alte Feuerwache, as an artistic contribution to the city's public space.\n\nThe figure represents Saint James the Greater, the patron saint of pilgrims and the namesake of the adjacent St. Jacobi Church. As Göttingen is situated on the historical Camino de Santiago (Way of St. James), the sculpture serves as an important landmark and symbol of the long tradition of pilgrimage in the region. The depiction eschews delicate details in favor of a powerful, almost archaic formal language, symbolizing the endurance of faith and the arduous journey of pilgrims.\n\nTechnically, the work is characterized by the use of concrete, a material Bernd Löning prefers for his creations. The artist, who began his career as a self-taught sculptor, is known for his works on the boundary between applied and fine arts. The robust nature of the material gives the sculpture a modern aesthetic that creates a compelling contrast with the Gothic architecture of the neighboring church."
+  },
+  "category": "kunstwerk",
+  "city": "Göttingen",
+  "country": "Germany",
+  "model": {
+    "glb": "/models/jakobus-skulptur-goettingen.glb",
+    "usdz": "/models/jakobus-skulptur-goettingen.usdz"
+  },
+  "photos": [
+    "/images/jakobus-skulptur-goettingen-2.png",
+    "/images/jakobus-skulptur-goettingen-3.png",
+    "/images/jakobus-skulptur-goettingen-4.png",
+    "/images/jakobus-skulptur-goettingen-5.png"
+  ],
+  "poster": "/images/jakobus-skulptur-goettingen-poster.png",
+  "location": {
+    "lat": 51.5350904,
+    "lng": 9.9362674,
+    "address": "Jüdenstraße 30, 37073 Göttingen, Deutschland"
+  },
+  "artist": "Bernd Löning",
+  "year": "2008",
+  "material": {
+    "de": "Beton",
+    "en": "Concrete"
+  }
+}

--- a/src/content/works/sonenuhr-goettingen.json
+++ b/src/content/works/sonenuhr-goettingen.json
@@ -1,0 +1,35 @@
+{
+  "title": {
+    "de": "sonnenuhr-goettingen",
+    "en": "goettingen-sundial"
+  },
+  "description": {
+    "de": "Die Sonnenuhr in Göttingen, entworfen von dem Physiker und Künstler Reinhold Wittig, ist ein markantes astronomisches Kunstwerk im öffentlichen Raum. Sie befindet sich in der Jüdenstraße, nördlich der Theaterstraße, und fungiert als eine der Stationen des Göttinger Planetenweges. Dieses wissenschaftliche Denkmal verbindet auf elegante Weise Zeitmessung mit künstlerischem Design und lädt Passanten dazu ein, die astronomischen Grundlagen unseres Alltags zu erkunden.\n\nDie Konstruktion zeichnet sich durch ihre präzise mathematische Ausrichtung aus, die für die korrekte Funktion einer Sonnenuhr unerlässlich ist. Als Teil des Planetenweges symbolisiert sie nicht nur den Lauf der Zeit, sondern auch die tief verwurzelte Tradition Göttingens als Stadt der Wissenschaft und Astronomie, die durch Persönlichkeiten wie Carl Friedrich Gauß geprägt wurde. Das Objekt dient somit sowohl als funktionales Instrument als auch als Bildungsmedium für die Öffentlichkeit.\n\nDas Design der Sonnenuhr ist modern und robust, passend für den städtischen Kontext. Durch die Verwendung von langlebigen Materialien bleibt das Kunstwerk witterungsbeständig und behält über Jahre hinweg seine ästhetische sowie funktionale Qualität. Es ist ein beliebtes Fotomotiv und ein wichtiger Orientierungspunkt für Besucher, die den astronomischen Lehrpfad der Stadt erkunden.",
+    "en": "The Göttingen Sundial, designed by physicist and artist Reinhold Wittig, is a prominent astronomical artwork located in the public space of Göttingen. Situated on Jüdenstraße, just north of Theaterstraße, it serves as a significant station along the Göttingen Planet Path (Planetenweg). This scientific monument elegantly combines timekeeping with artistic design, encouraging passersby to explore the astronomical foundations of our daily lives.\n\nThe construction is characterized by its precise mathematical alignment, which is essential for the accurate functioning of a sundial. As part of the Planet Path, it symbolizes not only the passage of time but also Göttingen's deep-rooted tradition as a city of science and astronomy, a legacy shaped by figures such as Carl Friedrich Gauss. The object thus functions as both a practical instrument and an educational tool for the general public.\n\nThe sundial's design is modern and robust, tailored for its urban environment. Utilizing durable materials, the artwork remains weather-resistant, maintaining its aesthetic and functional integrity over the years. It is a popular subject for photography and serves as an important landmark for visitors following the city's astronomical educational trail."
+  },
+  "category": "denkmal",
+  "city": "Göttingen",
+  "country": "Germany",
+  "model": {
+    "glb": "/models/sonnenuhr-goettingen.glb",
+    "usdz": "/models/sonnenuhr-goettingen.usdz"
+  },
+  "photos": [
+    "/images/sonnenuhr-goettingen-2.png",
+    "/images/sonnenuhr-goettingen-3.png",
+    "/images/sonnenuhr-goettingen-4.png",
+    "/images/sonnenuhr-goettingen-5.png"
+  ],
+  "poster": "/images/sonnenuhr-goettingen-poster.png",
+  "location": {
+    "lat": 51.5348,
+    "lng": 9.936438,
+    "address": "Jüdenstraße, 37073 Göttingen, Germany"
+  },
+  "artist": "Reinhold Wittig",
+  "year": "2003",
+  "material": {
+    "de": "Metall und Stein",
+    "en": "Metal and stone"
+  }
+}


### PR DESCRIPTION
Add three new content files for Göttingen artworks: die-heilige-eligia, jakobus-skulptur-goettingen, and sonnenuhr-goettingen. Each JSON includes bilingual title/description (de/en), category, city/country, 3D model paths (glb/usdz), photo lists and poster, geolocation address and coordinates, artist, year, and material metadata for use in the site’s public-art listings.