### PR TITLE
🔍️ Add city description i18n and use in CityPage

### DIFF
--- a/src/components/CityPage.astro
+++ b/src/components/CityPage.astro
@@ -1,7 +1,7 @@
 ---
 import Base from '@/layouts/Base.astro';
 import WorkCard from '@/components/WorkCard.astro';
-import { useTranslations, type Lang } from '@/i18n/ui';
+import { useTranslations, ui, type Lang } from '@/i18n/ui';
 import { getCollection } from 'astro:content';
 import { getAssetUrl } from '@/utils/assets';
 
@@ -17,7 +17,7 @@ const allWorks = await getCollection('works');
 const works = allWorks.filter((w) => w.data.city === cityName);
 ---
 
-<Base title={`${cityName} — Open Museum`} description={cityName}>
+<Base title={`${cityName} — Open Museum`} description={ui[lang]['city.description'](cityName, works.length)}>
   <!-- Page header -->
   <section class="bg-black text-white py-12 sm:py-16 border-b-brutal border-brand-gold">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -76,6 +76,9 @@ export const ui = {
     '404.message': 'Die angeforderte Seite existiert nicht.',
     '404.back': 'Zur Startseite',
 
+    // City page
+    'city.description': (city: string, count: number) => `Entdecken Sie ${count} Denkmäler, Brunnen und Kunstwerke in ${city} — interaktiv in 3D auf Open Museum.`,
+
     // Misc
     'loading': 'Wird geladen…',
     'noworks': 'Noch keine Werke in dieser Kategorie.',
@@ -149,6 +152,9 @@ export const ui = {
     '404.message': 'The requested page does not exist.',
     '404.back': 'Back to home',
 
+    // City page
+    'city.description': (city: string, count: number) => `Explore ${count} monuments, fountains, and artworks in ${city} — interactive in 3D on Open Museum.`,
+
     // Misc
     'loading': 'Loading…',
     'noworks': 'No works in this category yet.',
@@ -174,7 +180,7 @@ export function getLangFromUrl(url: URL): Lang {
  */
 export function useTranslations(lang: Lang) {
   return function t(key: UIKey): string {
-    return ui[lang][key] || ui[defaultLang][key];
+    return (ui[lang][key] || ui[defaultLang][key]) as string;
   };
 }
 


### PR DESCRIPTION
Introduce a new 'city.description' i18n key (DE/EN) that formats a localized page description using city name and work count. CityPage.astro now imports the ui map and uses ui[lang]['city.description'](cityName, works.length) for the Base description so the page meta is localized and includes the number of works. Also cast the translation lookup to string in useTranslations to satisfy typing when reading from the ui map.