### PR TITLE
:iphone: Fix AR Quick Look button clipped on iOS

### DIFF
--- a/src/components/ModelViewer.astro
+++ b/src/components/ModelViewer.astro
@@ -23,7 +23,7 @@ const { src, iosSrc, alt, poster, class: className = '' } = Astro.props;
     ar
     ar-modes="webxr scene-viewer quick-look"
     loading="lazy"
-    style="width: 100%; height: 100%; min-height: 400px;"
+    style="width: 100%; height: 100%;"
   >
     <div class="absolute inset-0 flex items-center justify-center bg-off-white" slot="poster">
       {poster ? (


### PR DESCRIPTION
Remove min-height: 400px from model-viewer inline style that caused it to overflow its aspect-square parent container on iOS devices. Combined with overflow-hidden on the container, this clipped the AR Quick Look button at the bottom edge. The model-viewer now sizes itself entirely from its parent chain (aspect-square + h-full), which already provides adequate dimensions on all screen sizes.