### PR TITLE
:construction_worker: Add CI asset health check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,20 @@ jobs:
         env:
           PUBLIC_ASSETS_BASE_URL: ${{ vars.PUBLIC_ASSETS_BASE_URL }}
 
+      - name: Validate changed pages assets
+        run: pnpm test:assets:changed
+        env:
+          GITHUB_BASE_SHA: ${{ github.event.before }}
+          GITHUB_HEAD_SHA: ${{ github.sha }}
+
+      - name: Upload asset health report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: asset-health-report
+          path: asset-health-report.md
+          if-no-files-found: warn
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ PUBLIC_ASSETS_BASE_URL=https://open-museum-885a1.firebasestorage.app
 - **With local assets**: Leave `PUBLIC_ASSETS_BASE_URL` empty and place asset files in `public/models/` and `public/images/works/` (these directories are gitignored)
 - **Switching providers**: Just change the URL — file paths are resolved at build time via [`src/utils/assets.ts`](src/utils/assets.ts)
 
+## CI Asset Health Check
+The deployment workflow includes an automated changed-page asset validation step:
+
+- Command: `pnpm test:assets:changed`
+- Script: `scripts/ci/asset-health-check.mjs`
+- Scope: validates only pages affected by changed content/routes in the current deployment diff
+- Checks:
+	- poster assets (e.g. `<model-viewer poster>` and `og:image`)
+	- photo assets (`<img src>`)
+	- 3D model sources (`<model-viewer src>` and `ios-src`)
+
+If validation fails, the workflow:
+
+- fails the build before deployment,
+- emits GitHub Actions error annotations per failed asset,
+- uploads `asset-health-report.md` as a workflow artifact,
+- writes the same report to the workflow step summary for quick triage.
+
 ## How to Contribute
 Feel free to contribute to this project in any way you can. Whether it's capturing new models, improving existing ones, or sharing feedback, your help is greatly appreciated!
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test:assets:changed": "node scripts/ci/asset-health-check.mjs"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.3.0",
@@ -18,6 +19,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
     "@tailwindcss/vite": "^4.0.0",
+    "cheerio": "^1.2.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.9.3",
     "vite": "6.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.0
         version: 4.1.18(vite@6.4.2(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      cheerio:
+        specifier: ^1.2.0
+        version: 1.2.0
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.18
@@ -1041,6 +1044,13 @@ packages:
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -1185,6 +1195,9 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   enhanced-resolve@5.19.0:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
@@ -1195,6 +1208,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   es-module-lexer@1.7.0:
@@ -1314,8 +1331,15 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
@@ -1680,6 +1704,12 @@ packages:
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -1801,6 +1831,9 @@ packages:
     resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sax@1.4.4:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
@@ -1931,6 +1964,10 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2178,6 +2215,15 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
@@ -3122,6 +3168,29 @@ snapshots:
 
   character-entities@2.0.2: {}
 
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.25.0
+      whatwg-mimetype: 4.0.0
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -3247,6 +3316,11 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   enhanced-resolve@5.19.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -3255,6 +3329,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -3462,7 +3538,18 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-cache-semantics@4.2.0: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   immediate@3.0.6: {}
 
@@ -3968,6 +4055,15 @@ snapshots:
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -4150,6 +4246,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
 
+  safer-buffer@2.1.2: {}
+
   sax@1.4.4: {}
 
   sax@1.6.0: {}
@@ -4292,6 +4390,8 @@ snapshots:
   ultrahtml@1.6.0: {}
 
   uncrypto@0.1.3: {}
+
+  undici@7.25.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -4493,6 +4593,12 @@ snapshots:
   vscode-uri@3.1.0: {}
 
   web-namespaces@2.0.1: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   which-pm-runs@1.1.0: {}
 

--- a/scripts/ci/asset-health-check.mjs
+++ b/scripts/ci/asset-health-check.mjs
@@ -1,0 +1,485 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { load } from 'cheerio';
+
+const REPO_ROOT = process.cwd();
+const DIST_DIR = path.join(REPO_ROOT, 'dist');
+const REPORT_PATH = path.join(REPO_ROOT, 'asset-health-report.md');
+const GITHUB_STEP_SUMMARY = process.env.GITHUB_STEP_SUMMARY;
+const HEAD_SHA = (process.env.GITHUB_HEAD_SHA || process.env.GITHUB_SHA || 'HEAD').trim();
+const BASE_SHA = (process.env.GITHUB_BASE_SHA || '').trim();
+const ZERO_SHA = /^0+$/;
+
+function run(command) {
+  try {
+    return execSync(command, { cwd: REPO_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function hasCommit(sha) {
+  if (!sha) return false;
+  return run(`git cat-file -e ${sha}^{commit}`) !== null;
+}
+
+function detectDiffRange() {
+  if (BASE_SHA && !ZERO_SHA.test(BASE_SHA) && hasCommit(BASE_SHA) && hasCommit(HEAD_SHA)) {
+    return `${BASE_SHA}..${HEAD_SHA}`;
+  }
+
+  if (hasCommit('HEAD~1')) {
+    return `HEAD~1..${HEAD_SHA}`;
+  }
+
+  return null;
+}
+
+function parseChangedFiles(diffRange) {
+  if (!diffRange) return [];
+
+  const raw = run(`git diff --name-status --find-renames ${diffRange}`);
+  if (!raw) return [];
+
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split('\t');
+      const status = parts[0] || '';
+      const kind = status[0] || '';
+
+      if (kind === 'R' || kind === 'C') {
+        return {
+          status,
+          kind,
+          oldPath: parts[1] || '',
+          newPath: parts[2] || '',
+        };
+      }
+
+      return {
+        status,
+        kind,
+        oldPath: '',
+        newPath: parts[1] || '',
+      };
+    });
+}
+
+function cityToSlug(value) {
+  return value
+    .toLowerCase()
+    .replace(/ö/g, 'oe')
+    .replace(/ü/g, 'ue')
+    .replace(/ä/g, 'ae')
+    .replace(/ß/g, 'ss')
+    .replace(/\s+/g, '-');
+}
+
+function routeFromPageFile(filePath) {
+  if (!filePath.startsWith('src/pages/') || !filePath.endsWith('.astro')) return null;
+
+  const rel = filePath.slice('src/pages/'.length).replace(/\.astro$/, '');
+  if (rel.includes('[')) {
+    return { route: null, dynamic: true };
+  }
+
+  if (rel === 'index') {
+    return { route: '/', dynamic: false };
+  }
+
+  if (rel.endsWith('/index')) {
+    return { route: `/${rel.slice(0, -'/index'.length)}/`, dynamic: false };
+  }
+
+  return { route: `/${rel}/`, dynamic: false };
+}
+
+async function loadWorkData(filePath) {
+  try {
+    const abs = path.join(REPO_ROOT, filePath);
+    const content = await fs.readFile(abs, 'utf8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+function addCategoryRoutes(routes, category) {
+  const map = {
+    brunnen: ['/brunnen/', '/en/fountains/'],
+    denkmal: ['/denkmale/', '/en/monuments/'],
+    kunstwerk: ['/kunstwerke/', '/en/artworks/'],
+  };
+
+  const categoryRoutes = map[category];
+  if (!categoryRoutes) return;
+
+  for (const route of categoryRoutes) routes.add(route);
+}
+
+function addCityRoutes(routes, city) {
+  if (!city) return;
+  const citySlug = cityToSlug(city);
+  routes.add(`/staedte/${citySlug}/`);
+  routes.add(`/en/cities/${citySlug}/`);
+}
+
+async function getTargetRoutes(changes) {
+  const routes = new Set();
+  let runAll = false;
+  let reason = '';
+
+  const globalAffectingRoots = [
+    'src/components/',
+    'src/layouts/',
+    'src/styles/',
+    'src/i18n/',
+    'src/utils/',
+  ];
+
+  for (const change of changes) {
+    const touched = [change.oldPath, change.newPath].filter(Boolean);
+
+    for (const filePath of touched) {
+      if (globalAffectingRoots.some((root) => filePath.startsWith(root)) || filePath === 'src/content.config.ts') {
+        runAll = true;
+        reason = `Global template/shared code changed: ${filePath}`;
+      }
+
+      if (filePath.startsWith('src/pages/') && filePath.endsWith('.astro')) {
+        const routeData = routeFromPageFile(filePath);
+        if (!routeData) continue;
+
+        if (routeData.dynamic) {
+          runAll = true;
+          reason = `Dynamic page template changed: ${filePath}`;
+        } else if (routeData.route) {
+          routes.add(routeData.route);
+        }
+      }
+
+      if (filePath.startsWith('src/content/works/') && filePath.endsWith('.json')) {
+        const slug = path.basename(filePath, '.json');
+        routes.add(`/werke/${slug}/`);
+        routes.add(`/en/works/${slug}/`);
+
+        const workData = await loadWorkData(filePath);
+        if (workData?.category) addCategoryRoutes(routes, workData.category);
+        if (workData?.city) addCityRoutes(routes, workData.city);
+      }
+    }
+  }
+
+  return { routes, runAll, reason };
+}
+
+async function listHtmlFiles(rootDir) {
+  const files = [];
+
+  async function walk(currentDir) {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const abs = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(abs);
+      } else if (entry.isFile() && entry.name.endsWith('.html')) {
+        files.push(abs);
+      }
+    }
+  }
+
+  await walk(rootDir);
+  return files;
+}
+
+function routeToDistPath(route) {
+  const cleanRoute = route.replace(/^\//, '').replace(/\/$/, '');
+  if (!cleanRoute) {
+    return path.join(DIST_DIR, 'index.html');
+  }
+
+  return path.join(DIST_DIR, cleanRoute, 'index.html');
+}
+
+function distPathToRoute(filePath) {
+  const rel = path.relative(DIST_DIR, filePath).replace(/\\/g, '/');
+  if (rel === 'index.html') return '/';
+  if (rel.endsWith('/index.html')) {
+    return `/${rel.slice(0, -'/index.html'.length)}/`;
+  }
+  return `/${rel}`;
+}
+
+function classifyImgType($img) {
+  const className = String($img.attr('class') || '');
+  if (className.includes('photo-gallery-thumb') || className.includes('photo-lightbox-img')) {
+    return 'photo';
+  }
+
+  return 'photo';
+}
+
+function collectAssets(html) {
+  const $ = load(html);
+  const assets = [];
+
+  $('model-viewer[src]').each((_, el) => {
+    const src = String($(el).attr('src') || '').trim();
+    if (src) assets.push({ type: 'model', source: src, tag: 'model-viewer[src]' });
+  });
+
+  $('model-viewer[ios-src]').each((_, el) => {
+    const src = String($(el).attr('ios-src') || '').trim();
+    if (src) assets.push({ type: 'model', source: src, tag: 'model-viewer[ios-src]' });
+  });
+
+  $('model-viewer[poster]').each((_, el) => {
+    const src = String($(el).attr('poster') || '').trim();
+    if (src) assets.push({ type: 'poster', source: src, tag: 'model-viewer[poster]' });
+  });
+
+  $('meta[property="og:image"]').each((_, el) => {
+    const src = String($(el).attr('content') || '').trim();
+    if (src) assets.push({ type: 'poster', source: src, tag: 'meta[property="og:image"]' });
+  });
+
+  $('img[src]').each((_, el) => {
+    const src = String($(el).attr('src') || '').trim();
+    if (src) assets.push({ type: classifyImgType($(el)), source: src, tag: 'img[src]' });
+  });
+
+  const deduped = [];
+  const seen = new Set();
+
+  for (const asset of assets) {
+    const key = `${asset.type}|${asset.source}|${asset.tag}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(asset);
+  }
+
+  return deduped;
+}
+
+function resolveAssetTarget(assetSource, route) {
+  if (!assetSource) return null;
+
+  const clean = assetSource.trim();
+  if (!clean || clean.startsWith('data:') || clean.startsWith('blob:')) return null;
+
+  if (clean.startsWith('//')) {
+    return { kind: 'remote', url: `https:${clean}`, label: `https:${clean}` };
+  }
+
+  if (/^https?:\/\//i.test(clean)) {
+    return { kind: 'remote', url: clean, label: clean };
+  }
+
+  const noQuery = clean.split('#')[0].split('?')[0];
+  if (!noQuery) return null;
+
+  let normalizedPath;
+  if (noQuery.startsWith('/')) {
+    normalizedPath = path.posix.normalize(noQuery);
+  } else {
+    const routeDir = route.endsWith('/') ? route : `${route}/`;
+    const routeAsFile = path.posix.join(routeDir, 'index.html');
+    const baseDir = path.posix.dirname(routeAsFile);
+    normalizedPath = path.posix.normalize(path.posix.join(baseDir, noQuery));
+    if (!normalizedPath.startsWith('/')) {
+      normalizedPath = `/${normalizedPath}`;
+    }
+  }
+
+  const localPath = path.join(DIST_DIR, normalizedPath.replace(/^\//, ''));
+  return { kind: 'local', filePath: localPath, label: normalizedPath };
+}
+
+async function checkRemoteAsset(url) {
+  const timeoutMs = 15000;
+
+  for (const method of ['HEAD', 'GET']) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        method,
+        redirect: 'follow',
+        signal: controller.signal,
+      });
+
+      clearTimeout(timer);
+
+      if (response.status < 400) {
+        return { ok: true, details: `${method} ${response.status}` };
+      }
+
+      if (method === 'HEAD' && (response.status === 405 || response.status === 501)) {
+        continue;
+      }
+
+      return { ok: false, details: `${method} ${response.status}` };
+    } catch (error) {
+      clearTimeout(timer);
+      if (method === 'HEAD') continue;
+      const message = error instanceof Error ? error.message : String(error);
+      return { ok: false, details: `${method} request failed: ${message}` };
+    }
+  }
+
+  return { ok: false, details: 'HEAD and GET failed' };
+}
+
+async function validateAsset(asset, route) {
+  const target = resolveAssetTarget(asset.source, route);
+  if (!target) {
+    return { ok: true };
+  }
+
+  if (target.kind === 'local') {
+    try {
+      const stat = await fs.stat(target.filePath);
+      if (!stat.isFile()) {
+        return { ok: false, reason: 'Path exists but is not a file', resolved: target.label };
+      }
+      if (stat.size === 0) {
+        return { ok: false, reason: 'File exists but is empty', resolved: target.label };
+      }
+      return { ok: true };
+    } catch {
+      return { ok: false, reason: 'File not found in dist output', resolved: target.label };
+    }
+  }
+
+  const remoteCheck = await checkRemoteAsset(target.url);
+  if (!remoteCheck.ok) {
+    return { ok: false, reason: remoteCheck.details, resolved: target.label };
+  }
+
+  return { ok: true };
+}
+
+function toErrorTitle(assetType) {
+  if (assetType === 'poster') return 'Poster not loaded';
+  if (assetType === 'model') return '3D model unavailable';
+  return 'Missing or broken photo';
+}
+
+function toMarkdownTable(rows) {
+  if (rows.length === 0) return '_No asset errors detected._';
+
+  const header = '| Page | Type | Asset | Error |\n|---|---|---|---|';
+  const body = rows
+    .map((row) => `| ${row.route} | ${row.type} | ${row.asset} | ${row.error} |`)
+    .join('\n');
+
+  return `${header}\n${body}`;
+}
+
+async function main() {
+  const diffRange = detectDiffRange();
+  const changes = parseChangedFiles(diffRange);
+  const { routes, runAll, reason } = await getTargetRoutes(changes);
+
+  const reportLines = [];
+  reportLines.push('# Asset Health Check Report');
+  reportLines.push('');
+  reportLines.push(`- Timestamp: ${new Date().toISOString()}`);
+  reportLines.push(`- Diff range: ${diffRange ?? 'N/A (single-commit or first deployment fallback)'}`);
+  reportLines.push(`- Changed files scanned: ${changes.length}`);
+
+  if (runAll) {
+    reportLines.push(`- Mode: Full-page scan (${reason || 'shared files changed'})`);
+  } else {
+    reportLines.push('- Mode: Changed-page scan');
+  }
+
+  const allHtml = await listHtmlFiles(DIST_DIR);
+  const candidatePages = [];
+
+  if (runAll) {
+    for (const filePath of allHtml) {
+      const route = distPathToRoute(filePath);
+      if (route === '/404.html') continue;
+      candidatePages.push({ route, filePath });
+    }
+  } else {
+    for (const route of routes) {
+      const filePath = routeToDistPath(route);
+      try {
+        await fs.access(filePath);
+        candidatePages.push({ route, filePath });
+      } catch {
+        // Skip routes that do not exist in the current build output (e.g. removed pages)
+      }
+    }
+  }
+
+  reportLines.push(`- Target pages: ${candidatePages.length}`);
+
+  if (candidatePages.length === 0) {
+    reportLines.push('');
+    reportLines.push('## Result');
+    reportLines.push('No affected pages were detected for this deployment. Validation skipped.');
+
+    const report = `${reportLines.join('\n')}\n`;
+    await fs.writeFile(REPORT_PATH, report, 'utf8');
+    if (GITHUB_STEP_SUMMARY) await fs.appendFile(GITHUB_STEP_SUMMARY, `\n${report}\n`, 'utf8');
+
+    console.log('Asset health check skipped: no affected routes detected.');
+    return;
+  }
+
+  const failures = [];
+  let inspectedAssets = 0;
+
+  for (const page of candidatePages) {
+    const html = await fs.readFile(page.filePath, 'utf8');
+    const assets = collectAssets(html);
+
+    for (const asset of assets) {
+      inspectedAssets += 1;
+      const result = await validateAsset(asset, page.route);
+      if (!result.ok) {
+        failures.push({
+          route: page.route,
+          type: asset.type,
+          asset: asset.source,
+          error: result.reason || 'Unknown error',
+        });
+
+        const title = toErrorTitle(asset.type);
+        const resolved = result.resolved ? ` (resolved: ${result.resolved})` : '';
+        console.error(`::error title=${title}::${page.route} -> ${asset.source}${resolved}: ${result.reason}`);
+      }
+    }
+  }
+
+  reportLines.push(`- Assets inspected: ${inspectedAssets}`);
+  reportLines.push(`- Failures: ${failures.length}`);
+  reportLines.push('');
+  reportLines.push('## Failures');
+  reportLines.push(toMarkdownTable(failures));
+
+  const report = `${reportLines.join('\n')}\n`;
+  await fs.writeFile(REPORT_PATH, report, 'utf8');
+  if (GITHUB_STEP_SUMMARY) await fs.appendFile(GITHUB_STEP_SUMMARY, `\n${report}\n`, 'utf8');
+
+  if (failures.length > 0) {
+    throw new Error(`Asset health check failed with ${failures.length} issue(s). See asset-health-report.md.`);
+  }
+
+  console.log(`Asset health check passed for ${candidatePages.length} page(s) and ${inspectedAssets} asset(s).`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Introduce a CI asset health check to validate posters, photos and 3D models for changed pages before deployment. Adds a new script scripts/ci/asset-health-check.mjs, a package.json script (test:assets:changed) and cheerio dependency, and wires the check into .github/workflows/deploy.yml (runs the check and uploads asset-health-report.md as an artifact). README updated with documentation for the CI check and pnpm-lock.yaml updated to include the new dependency tree. The check inspects only affected pages (or falls back to a full scan when necessary), emits GitHub Actions error annotations on failures, writes a step summary and uploads a report; the workflow will fail when issues are found.