### PR TITLE
:zap: Add work gallery thumbnail generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 public/models/
 public/images/works/
 public/images/slideshow/
+public/images/thumbnails/works/
 
 # Editor
 .vscode/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ PUBLIC_ASSETS_BASE_URL=https://open-museum-885a1.firebasestorage.app
 - **With local assets**: Leave `PUBLIC_ASSETS_BASE_URL` empty and place asset files in `public/models/` and `public/images/works/` (these directories are gitignored)
 - **Switching providers**: Just change the URL — file paths are resolved at build time via [`src/utils/assets.ts`](src/utils/assets.ts)
 
+## Gallery Thumbnails (Build-Time Optimization)
+Work-page gallery images now use generated `.webp` thumbnails for initial render and only load the full-size photo when the user opens the lightbox.
+
+- Generator script: `pnpm thumbs:generate`
+- Script source: `scripts/generate-work-photo-thumbnails.mjs`
+- Auto-run before build: `prebuild` runs the generator automatically
+- Output directory: `public/images/thumbnails/works/`
+
+The generator reads all `photos` arrays from `src/content/works/*.json` (gallery photos only), then:
+
+- fetches originals from `PUBLIC_ASSETS_BASE_URL` when set (Firebase-compatible URL handling), or
+- reads originals from local `public/` when external storage is not configured.
+
+Optional tuning via environment variables:
+
+- `WORK_THUMBNAIL_WIDTH` (default: `900`)
+- `WORK_THUMBNAIL_QUALITY` (default: `72`)
+- `WORK_THUMBNAIL_CONCURRENCY` (default: `4`)
+
 ## CI Asset Health Check
 The deployment workflow includes an automated changed-page asset validation step:
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "thumbs:generate": "node scripts/generate-work-photo-thumbnails.mjs",
+    "prebuild": "pnpm thumbs:generate",
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
@@ -20,6 +22,7 @@
     "@astrojs/check": "^0.9.6",
     "@tailwindcss/vite": "^4.0.0",
     "cheerio": "^1.2.0",
+    "sharp": "^0.34.5",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.9.3",
     "vite": "6.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.18
@@ -2600,8 +2603,7 @@ snapshots:
       lit: 3.3.2
       three: 0.172.0
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -4284,7 +4286,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shiki@3.23.0:
     dependencies:

--- a/scripts/generate-work-photo-thumbnails.mjs
+++ b/scripts/generate-work-photo-thumbnails.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import sharp from 'sharp';
+
+const REPO_ROOT = process.cwd();
+const WORKS_CONTENT_DIR = path.join(REPO_ROOT, 'src/content/works');
+const PUBLIC_DIR = path.join(REPO_ROOT, 'public');
+const THUMBNAIL_DIR = path.join(PUBLIC_DIR, 'images/thumbnails/works');
+
+const THUMBNAIL_WIDTH = Number(process.env.WORK_THUMBNAIL_WIDTH || 900);
+const THUMBNAIL_QUALITY = Number(process.env.WORK_THUMBNAIL_QUALITY || 72);
+const CONCURRENCY = Number(process.env.WORK_THUMBNAIL_CONCURRENCY || 4);
+const FORCE_REGENERATE = process.argv.includes('--force');
+
+function stripQueryAndHash(value) {
+  return value.split('#')[0].split('?')[0];
+}
+
+function getThumbnailPath(photoPath) {
+  const cleanPath = stripQueryAndHash(photoPath).trim();
+  const normalizedPath = cleanPath.startsWith('/') ? cleanPath.slice(1) : cleanPath;
+  return `/images/thumbnails/works/${encodeURIComponent(normalizedPath)}.webp`;
+}
+
+function toRemoteAssetUrl(assetPath, baseUrl) {
+  const normalizedBase = baseUrl.replace(/\/+$/, '');
+  const normalizedPath = assetPath.startsWith('/') ? assetPath.slice(1) : assetPath;
+
+  if (normalizedBase.includes('firebasestorage.googleapis.com')) {
+    return `${normalizedBase}/${encodeURIComponent(normalizedPath)}?alt=media`;
+  }
+
+  return `${normalizedBase}/${normalizedPath}`;
+}
+
+async function pathExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listJsonFilesRecursively(dirPath) {
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const absPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listJsonFilesRecursively(absPath)));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.json')) {
+      files.push(absPath);
+    }
+  }
+
+  return files;
+}
+
+function parseEnvVariable(rawEnv, key) {
+  const lines = rawEnv.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    if (!trimmed.startsWith(`${key}=`)) continue;
+
+    let value = trimmed.slice(key.length + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+
+    return value;
+  }
+
+  return '';
+}
+
+async function loadPublicAssetsBaseUrl() {
+  if (process.env.PUBLIC_ASSETS_BASE_URL) {
+    return process.env.PUBLIC_ASSETS_BASE_URL.trim();
+  }
+
+  const envCandidates = ['.env', '.env.local'];
+
+  for (const envFile of envCandidates) {
+    const absPath = path.join(REPO_ROOT, envFile);
+    if (!(await pathExists(absPath))) continue;
+    const content = await fs.readFile(absPath, 'utf8');
+    const value = parseEnvVariable(content, 'PUBLIC_ASSETS_BASE_URL');
+    if (value) return value;
+  }
+
+  return '';
+}
+
+async function getPhotoSourceBuffer(photoPath, publicAssetsBaseUrl) {
+  if (/^https?:\/\//i.test(photoPath)) {
+    const response = await fetch(photoPath);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} while fetching ${photoPath}`);
+    }
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  if (publicAssetsBaseUrl) {
+    const remoteUrl = toRemoteAssetUrl(photoPath, publicAssetsBaseUrl);
+    const response = await fetch(remoteUrl);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} while fetching ${remoteUrl}`);
+    }
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  const localPhotoPath = stripQueryAndHash(photoPath).replace(/^\/+/, '');
+  const absLocalPath = path.join(PUBLIC_DIR, localPhotoPath);
+  return fs.readFile(absLocalPath);
+}
+
+async function runWithConcurrency(items, limit, worker) {
+  const inFlight = new Set();
+
+  for (const item of items) {
+    const task = Promise.resolve().then(() => worker(item));
+    inFlight.add(task);
+    task.finally(() => inFlight.delete(task));
+
+    if (inFlight.size >= limit) {
+      await Promise.race(inFlight);
+    }
+  }
+
+  await Promise.all(inFlight);
+}
+
+async function main() {
+  const publicAssetsBaseUrl = await loadPublicAssetsBaseUrl();
+  const workJsonFiles = await listJsonFilesRecursively(WORKS_CONTENT_DIR);
+  const photoSet = new Set();
+
+  for (const filePath of workJsonFiles) {
+    const raw = await fs.readFile(filePath, 'utf8');
+    let parsed;
+
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      console.warn(`[thumbnail] Skipping invalid JSON: ${path.relative(REPO_ROOT, filePath)} (${error.message})`);
+      continue;
+    }
+
+    if (!Array.isArray(parsed.photos)) continue;
+
+    for (const photo of parsed.photos) {
+      if (typeof photo === 'string' && photo.trim()) {
+        photoSet.add(photo.trim());
+      }
+    }
+  }
+
+  const photos = [...photoSet];
+
+  await fs.mkdir(THUMBNAIL_DIR, { recursive: true });
+
+  let generatedCount = 0;
+  let skippedCount = 0;
+  const failed = [];
+
+  await runWithConcurrency(photos, Math.max(1, CONCURRENCY), async (photo) => {
+    const thumbnailPath = getThumbnailPath(photo);
+    const absThumbnailPath = path.join(PUBLIC_DIR, thumbnailPath.replace(/^\/+/, ''));
+
+    await fs.mkdir(path.dirname(absThumbnailPath), { recursive: true });
+
+    if (!FORCE_REGENERATE && (await pathExists(absThumbnailPath))) {
+      skippedCount += 1;
+      return;
+    }
+
+    try {
+      const sourceBuffer = await getPhotoSourceBuffer(photo, publicAssetsBaseUrl);
+
+      await sharp(sourceBuffer)
+        .rotate()
+        .resize({ width: THUMBNAIL_WIDTH, withoutEnlargement: true })
+        .webp({ quality: THUMBNAIL_QUALITY, effort: 4 })
+        .toFile(absThumbnailPath);
+
+      generatedCount += 1;
+    } catch (error) {
+      failed.push({ photo, error: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  console.log(`[thumbnail] Work gallery photos discovered: ${photos.length}`);
+  console.log(`[thumbnail] Generated: ${generatedCount}`);
+  console.log(`[thumbnail] Skipped existing: ${skippedCount}`);
+
+  if (failed.length > 0) {
+    console.warn(`[thumbnail] Failed: ${failed.length}`);
+    for (const entry of failed) {
+      console.warn(`[thumbnail] - ${entry.photo}: ${entry.error}`);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(`[thumbnail] Fatal error: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/src/components/WorkPage.astro
+++ b/src/components/WorkPage.astro
@@ -4,6 +4,7 @@ import ModelViewer from '@/components/ModelViewer.astro';
 import { useTranslations, getCategoryPath, getWorkPath, type Lang } from '@/i18n/ui';
 import { marked } from 'marked';
 import { getAssetUrl } from '@/utils/assets';
+import { getPublicUrl, getWorkPhotoThumbnailPath } from '@/utils/photo-thumbnails';
 
 interface Props {
   work: any;
@@ -26,6 +27,10 @@ const categoryUrl = `${siteUrl}${getCategoryPath(lang, category)}`;
 const licenseUrl = lang === 'de'
   ? 'https://creativecommons.org/licenses/by-nc/4.0/deed.de'
   : 'https://creativecommons.org/licenses/by-nc/4.0/';
+const galleryPhotos = data.photos.map((photo: string) => ({
+  fullUrl: getAssetUrl(photo),
+  thumbUrl: getPublicUrl(getWorkPhotoThumbnailPath(photo)),
+}));
 
 const visualArtworkSchema = {
   '@context': 'https://schema.org',
@@ -122,15 +127,15 @@ const breadcrumbSchema = {
           </div>
         )}
 
-        {data.photos.length > 0 && (
+        {galleryPhotos.length > 0 && (
           <div>
             <h2 class="font-heading text-xl font-bold uppercase tracking-wider mb-4">
               {t('work.photos')}
             </h2>
             <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
-              {data.photos.map((photo: string) => (
+              {galleryPhotos.map((photo) => (
                 <div class="brutal-card overflow-hidden aspect-square">
-                  <img src={getAssetUrl(photo)} alt={data.title[lang]} class="w-full h-full object-cover cursor-pointer photo-gallery-thumb" data-full={getAssetUrl(photo)} loading="lazy" />
+                  <img src={photo.thumbUrl} alt={data.title[lang]} class="w-full h-full object-cover cursor-pointer photo-gallery-thumb" data-full={photo.fullUrl} loading="lazy" decoding="async" onerror="this.onerror=null;this.src=this.dataset.full||'';" />
                 </div>
               ))}
             </div>

--- a/src/utils/photo-thumbnails.ts
+++ b/src/utils/photo-thumbnails.ts
@@ -1,0 +1,20 @@
+function stripQueryAndHash(path: string): string {
+  return path.split('#')[0].split('?')[0];
+}
+
+export function getWorkPhotoThumbnailPath(photoPath: string): string {
+  const cleanPath = stripQueryAndHash(photoPath).trim();
+  const normalizedPath = cleanPath.startsWith('/') ? cleanPath.slice(1) : cleanPath;
+  return `/images/thumbnails/works/${encodeURIComponent(normalizedPath)}.webp`;
+}
+
+export function getPublicUrl(path: string): string {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const base = import.meta.env.BASE_URL;
+  const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+  const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
+  return `${normalizedBase}${normalizedPath}`;
+}


### PR DESCRIPTION
Add a build-time thumbnail generator and integrate thumbnails into the work gallery.

- New script scripts/generate-work-photo-thumbnails.mjs: scans src/content/works/*.json for gallery photos and generates .webp thumbnails into public/images/thumbnails/works/ (supports remote PUBLIC_ASSETS_BASE_URL or local public/, configurable width/quality/concurrency, and --force).
- Add pnpm script thumbs:generate and run it automatically via prebuild. Add sharp dependency for image processing.
- New utility src/utils/photo-thumbnails.ts exposing getWorkPhotoThumbnailPath and getPublicUrl.
- WorkPage.astro updated to use generated thumbnail URLs for initial renders and lazy-fallback to full images via data-full/onerror.
- README updated with usage and env vars; public/images/thumbnails/works/ added to .gitignore.