### PR TITLE
⬆️ Pin fast-uri to 3.1.3 (Dependabot #60)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "yaml": "2.8.3",
       "websocket-driver": "0.7.5",
       "undici": "7.28.0",
-      "protobufjs": "7.6.1"
+      "protobufjs": "7.6.1",
+      "fast-uri": "3.1.3"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   websocket-driver: 0.7.5
   undici: 7.28.0
   protobufjs: 7.6.1
+  fast-uri: 3.1.3
 
 importers:
 
@@ -1711,8 +1712,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -3947,7 +3948,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4296,7 +4297,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.3: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Pins transitive `fast-uri` to **3.1.3** via `pnpm.overrides` to fix [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) / CVE-2026-13676 ([Dependabot #60](https://github.com/nuit-dhiver/Open-Museum/security/dependabot/60)).
- Pulled in through `@astrojs/check` → `@astrojs/language-server` → `volar-service-yaml` → `yaml-language-server` → `ajv`.

## Test plan
- [ ] Confirm `pnpm why fast-uri` reports `3.1.3`
- [ ] Confirm Dependabot alert #60 closes after merge
- [ ] Smoke-check app still builds (`pnpm build`) if CI does not cover it


Made with [Cursor](https://cursor.com)