### PR TITLE
⬆️ Bump fast-uri to 3.1.4 (Dependabot #61)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       "websocket-driver": "0.7.5",
       "undici": "7.28.0",
       "protobufjs": "7.6.1",
-      "fast-uri": "3.1.3"
+      "fast-uri": "3.1.4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   websocket-driver: 0.7.5
   undici: 7.28.0
   protobufjs: 7.6.1
-  fast-uri: 3.1.3
+  fast-uri: 3.1.4
 
 importers:
 
@@ -1712,8 +1712,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -3948,7 +3948,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4297,7 +4297,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Bumps the `fast-uri` pnpm override from **3.1.3** to **3.1.4** to fix [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) / CVE-2026-16221 ([Dependabot #61](https://github.com/nuit-dhiver/Open-Museum/security/dependabot/61)).
- `3.1.3` (from #60) is still in the vulnerable range `<= 3.1.3`.

## Test plan
- [ ] Confirm `pnpm why fast-uri` reports `3.1.4`
- [ ] Confirm Dependabot alert #61 closes after merge
- [ ] Smoke-check app still builds (`pnpm build`) if CI does not cover it


Made with [Cursor](https://cursor.com)